### PR TITLE
default `Ok` instance values to `True`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,16 @@ Access the value directly, without any other checks (like ``unwrap()`` in Rust):
 
 Note that this is a property, you cannot assign to it. Results are immutable.
 
+For your convenience, simply creating an `Ok` result without value is the same as using `True`::
+
+    >>> res1 = Result.Ok()
+    >>> res1.value
+    True
+    >>> res2 = Ok()
+    >>> res2.value
+    True
+
+
 In case you're missing methods like ``unwrap_or(default)``, these can be
 achieved by regular Python constructs::
 

--- a/result/result.py
+++ b/result/result.py
@@ -17,7 +17,7 @@ class Result(object):
                                "Use the Ok(value) and Err(error) class methods instead.")
 
     @classmethod
-    def Ok(cls, value):
+    def Ok(cls, value=True):
         instance = cls(force=True)
         instance._val = value
         instance._type = 'ok'
@@ -58,7 +58,7 @@ class Result(object):
     # TODO: Implement __iter__ for destructuring
 
 
-def Ok(value):
+def Ok(value=True):
     """
     Shortcut function to create a new Result.
     """


### PR DESCRIPTION
I have seen `result` used in Python code where the main differentiation was between "no error" and "error". Since we didn't really care about the return value, the call was

`return Ok(True)`

This was repeated in several places and just looks funny. The actual value of the default setting doesn't even matter, just the fact that there is one would make usability better.