### PR TITLE
__eq__ magic method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Possible log types:
 
 ## [Unreleased]
 
- - ...
+ - [added] and_then and or_else control flow methods
 
 ## [0.2.0] - 2016-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Possible log types:
 
 ## [Unreleased]
 
- - [added] and_then and or_else control flow methods
+ - [added] __eq__ magic method
 
 ## [0.2.0] - 2016-05-05
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,24 @@ Access the value directly, without any other checks (like ``unwrap()`` in Rust):
 
 Note that this is a property, you cannot assign to it. Results are immutable.
 
+Calls a function if the result is Err, otherwise returns self::
+
+    >>> Ok(1).or_else(lambda x: Ok(x * 2)) == Ok(2)
+    False
+    >>> Err(1).or_else(lambda x: Ok(x * 2)) == Ok(2)
+    True
+    >>> Err(1).or_else(lambda x, y: Ok(x * y), y=2) == Ok(2)
+    True
+
+Calls a function if the result is Ok, otherwise returns self::
+
+    >>> Ok(1).and_then(lambda x: Ok(x * 2)) == Ok(2)
+    True
+    >>> Err(1).and_then(lambda x: Ok(x * 2)) == Ok(2)
+    False
+    >>> Ok(1).and_then(lambda x, y: Ok(x * y), y=2) == Ok(2)
+    True
+
 For your convenience, simply creating an `Ok` result without value is the same as using `True`::
 
     >>> res1 = Result.Ok()

--- a/README.rst
+++ b/README.rst
@@ -122,24 +122,6 @@ Access the value directly, without any other checks (like ``unwrap()`` in Rust):
 
 Note that this is a property, you cannot assign to it. Results are immutable.
 
-Calls a function if the result is Err, otherwise returns self::
-
-    >>> Ok(1).or_else(lambda x: Ok(x * 2)) == Ok(2)
-    False
-    >>> Err(1).or_else(lambda x: Ok(x * 2)) == Ok(2)
-    True
-    >>> Err(1).or_else(lambda x, y: Ok(x * y), y=2) == Ok(2)
-    True
-
-Calls a function if the result is Ok, otherwise returns self::
-
-    >>> Ok(1).and_then(lambda x: Ok(x * 2)) == Ok(2)
-    True
-    >>> Err(1).and_then(lambda x: Ok(x * 2)) == Ok(2)
-    False
-    >>> Ok(1).and_then(lambda x, y: Ok(x * y), y=2) == Ok(2)
-    True
-
 For your convenience, simply creating an `Ok` result without value is the same as using `True`::
 
     >>> res1 = Result.Ok()

--- a/result/result.py
+++ b/result/result.py
@@ -52,22 +52,6 @@ class Result(object):
         """
         return self._val if self.is_err() else None
 
-    def and_then(self, function, **kwargs):
-        """
-        Return the error if this is an `Err` type. Return `function` calls return value otherwise.
-        """
-        if self._type == 'error':
-            return self
-        return function(self._val, **kwargs)
-
-    def or_else(self, function, **kwargs):
-        """
-        Return the error if this is an `Ok` type. Return `function` calls return value otherwise.
-        """
-        if self._type == 'ok':
-            return self
-        return function(self._val, **kwargs)
-
     @property
     def value(self):
         """

--- a/result/result.py
+++ b/result/result.py
@@ -16,6 +16,10 @@ class Result(object):
             raise RuntimeError("Don't instantiate a Result directly. "
                                "Use the Ok(value) and Err(error) class methods instead.")
 
+    def __eq__(self, other):
+        return self._type == other._type and self._val == other._val
+
+
     @classmethod
     def Ok(cls, value=True):
         instance = cls(force=True)
@@ -47,6 +51,22 @@ class Result(object):
         Return the error if this is an `Err` type. Return `None` otherwise.
         """
         return self._val if self.is_err() else None
+
+    def and_then(self, function, **kwargs):
+        """
+        Return the error if this is an `Err` type. Return `function` calls return value otherwise.
+        """
+        if self._type == 'error':
+            return self
+        return function(self._val, **kwargs)
+
+    def or_else(self, function, **kwargs):
+        """
+        Return the error if this is an `Ok` type. Return `function` calls return value otherwise.
+        """
+        if self._type == 'ok':
+            return self
+        return function(self._val, **kwargs)
 
     @property
     def value(self):

--- a/result/tests.py
+++ b/result/tests.py
@@ -58,24 +58,6 @@ def test_err_method():
     assert n.err() == 'nay'
 
 
-def test_and_ten():
-    def sq(x):
-        return Ok(x * x)
-
-    assert Ok(2).and_then(sq) == Ok(4)
-    assert Err(2).and_then(sq) == Err(2)
-    assert Ok(2).and_then(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
-
-
-def test_or_else():
-    def sq(x):
-        return Ok(x * x)
-
-    assert Ok(2).or_else(sq) == Ok(2)
-    assert Err(2).or_else(sq) == Ok(4)
-    assert Err(2).or_else(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
-
-
 def test_no_constructor():
     """
     Constructor should not be used directly.

--- a/result/tests.py
+++ b/result/tests.py
@@ -65,7 +65,6 @@ def test_and_ten():
     assert Ok(2).and_then(sq) == Ok(4)
     assert Err(2).and_then(sq) == Err(2)
     assert Ok(2).and_then(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
-    assert Ok((1, 2, 3)).and_then(lambda (x, y, z): Ok(x * y * z)) == Ok(6)
 
 
 def test_or_else():
@@ -75,7 +74,6 @@ def test_or_else():
     assert Ok(2).or_else(sq) == Ok(2)
     assert Err(2).or_else(sq) == Ok(4)
     assert Err(2).or_else(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
-    assert Err((1, 2, 3)).or_else(lambda (x, y, z): Ok(x * y * z)) == Ok(6)
 
 
 def test_no_constructor():

--- a/result/tests.py
+++ b/result/tests.py
@@ -23,6 +23,13 @@ def test_err_factories(instance):
     instance.is_err() is True
 
 
+def test_eq():
+    assert Ok(1) == Ok(1)
+    assert Err(1) == Err(1)
+    assert Ok(1) != Err(1)
+    assert Ok(1) != Ok(2)
+
+
 def test_ok():
     res = Ok('haha')
     res.is_ok() is True
@@ -49,6 +56,26 @@ def test_err_method():
     n = Err('nay')
     assert o.err() is None
     assert n.err() == 'nay'
+
+
+def test_and_ten():
+    def sq(x):
+        return Ok(x * x)
+
+    assert Ok(2).and_then(sq) == Ok(4)
+    assert Err(2).and_then(sq) == Err(2)
+    assert Ok(2).and_then(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
+    assert Ok((1, 2, 3)).and_then(lambda (x, y, z): Ok(x * y * z)) == Ok(6)
+
+
+def test_or_else():
+    def sq(x):
+        return Ok(x * x)
+
+    assert Ok(2).or_else(sq) == Ok(2)
+    assert Err(2).or_else(sq) == Ok(4)
+    assert Err(2).or_else(lambda x, y, z: Ok(x * y * z), y=2, z=4) == Ok(16)
+    assert Err((1, 2, 3)).or_else(lambda (x, y, z): Ok(x * y * z)) == Ok(6)
 
 
 def test_no_constructor():


### PR DESCRIPTION
Happy to see this module exists.
I was toying with it the other day and felt I could make my code simpler using a bit of chaining.
So here are the [and_then](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then) and [or_else}(https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else) inspired methods.

I added the kwargs option for more flexibility (and clarity)

I also added the __eq__  magic method as Ok(1) was not equal to Ok(1)