### PR TITLE
Added `unwrap`, `unwrap_or` and `expect`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Convert a Result to the error or ``None``::
     >>> res2.err()
     'nay'
 
-Access the value directly, without any other checks (like ``unwrap()`` in Rust)::
+Access the value directly, without any other checks::
 
     >>> res1 = Ok('yay')
     >>> res2 = Err('nay')
@@ -127,15 +127,41 @@ For your convenience, simply creating an `Ok` result without value is the same a
     >>> res2.value
     True
 
-
-In case you're missing methods like ``unwrap_or(default)``, these can be
-achieved by regular Python constructs::
+The `unwrap` method returns the value if `Ok`, otherwise it raises an `UnwrapError`::
 
     >>> res1 = Ok('yay')
     >>> res2 = Err('nay')
-    >>> res1.ok() or 'default'
+    >>> res1.unwrap()
     'yay'
-    >>> res2.ok() or 'default'
+    >>> res2.unwrap()
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "C:\project\result\result.py", line 107, in unwrap
+        return self.expect("Called `Result.unwrap()` on an `Err` value")
+    File "C:\project\result\result.py", line 101, in expect
+        raise UnwrapError(message)
+    result.result.UnwrapError: Called `Result.unwrap()` on an `Err` value
+
+A custom error message can be displayed instead by using `expect`::
+
+    >>> res1 = Ok('yay')
+    >>> res2 = Err('nay')
+    >>> res1.expect('not ok')
+    'yay'
+    >>> res2.expect('not ok')
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "C:\project\result\result.py", line 101, in expect
+        raise UnwrapError(message)
+    result.result.UnwrapError: not ok
+
+A default value can be returned instead by using `unwrap_or`::
+
+    >>> res1 = Ok('yay')
+    >>> res2 = Err('nay')
+    >>> res1.unwrap_or('default')
+    'yay'
+    >>> res2.unwrap_or('default')
     'default'
 
 

--- a/result/__init__.py
+++ b/result/__init__.py
@@ -1,2 +1,2 @@
-from .result import Result, Ok, Err
-__all__ = ['Result', 'Ok', 'Err']
+from .result import Result, Ok, Err, UnwrapError
+__all__ = ['Result', 'Ok', 'Err', 'UnwrapError']

--- a/result/result.py
+++ b/result/result.py
@@ -96,7 +96,7 @@ class Result(Generic[E, T]):
         Return the value if it is an `Ok` type. Raises an `UnwrapError` if it is an `Err`.
         """
         if self._is_ok:
-            return self._value
+            return cast(T, self._value)
         else:
             raise UnwrapError(message)
 
@@ -111,7 +111,7 @@ class Result(Generic[E, T]):
         Return the value if it is an `Ok` type. Return `default` if it is an `Err`.
         """
         if self._is_ok:
-            return self._value
+            return cast(T, self._value)
         else:
             return default
 

--- a/result/result.py
+++ b/result/result.py
@@ -106,6 +106,15 @@ class Result(Generic[E, T]):
         """
         return self.expect("Called `Result.unwrap()` on an `Err` value")
 
+    def unwrap_or(self, default: T) -> T:
+        """
+        Return the value if it is an `Ok` type. Return `default` if it is an `Err`.
+        """
+        if self._is_ok:
+            return self._value
+        else:
+            return default
+
     # TODO: Implement __iter__ for destructuring
 
 

--- a/result/result.py
+++ b/result/result.py
@@ -91,6 +91,21 @@ class Result(Generic[E, T]):
         """
         return self._value
 
+    def expect(self, message: str) -> T:
+        """
+        Return the value if it is an `Ok` type. Raises an `UnwrapError` if it is an `Err`.
+        """
+        if self._is_ok:
+            return self._value
+        else:
+            raise UnwrapError(message)
+
+    def unwrap(self) -> T:
+        """
+        Return the value if it is an `Ok` type. Raises an `UnwrapError` if it is an `Err`.
+        """
+        return self.expect("Called `Result.unwrap()` on an `Err` value")
+
     # TODO: Implement __iter__ for destructuring
 
 
@@ -116,3 +131,7 @@ def Err(error: E) -> Result[E, T]:
     Shortcut function to create a new Result.
     """
     return Result.Err(error)
+
+
+class UnwrapError(Exception):
+    pass

--- a/result/tests.py
+++ b/result/tests.py
@@ -105,3 +105,10 @@ def test_expect():
     assert o.expect('failure') == 'yay'
     with pytest.raises(UnwrapError):
         n.expect('failure')
+
+
+def test_unwrap_or():
+    o = Ok('yay')
+    n = Err('nay')
+    assert o.unwrap_or('some_default') == 'yay'
+    assert n.unwrap_or('another_default') == 'another_default'

--- a/result/tests.py
+++ b/result/tests.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from result import Result, Ok, Err
+from result import Result, Ok, Err, UnwrapError
 
 
 @pytest.mark.parametrize('instance', [
@@ -89,3 +89,19 @@ def test_no_constructor():
     """
     with pytest.raises(RuntimeError):
         Result(is_ok=True, value='yay')
+
+
+def test_unwrap():
+    o = Ok('yay')
+    n = Err('nay')
+    assert o.unwrap() == 'yay'
+    with pytest.raises(UnwrapError):
+        n.unwrap()
+
+
+def test_expect():
+    o = Ok('yay')
+    n = Err('nay')
+    assert o.expect('failure') == 'yay'
+    with pytest.raises(UnwrapError):
+        n.expect('failure')


### PR DESCRIPTION
This PR adds the `unwrap`, `unwrap_or` and `expect` methods to `Result`, as suggested in #3.