### PR TITLE
Added unwrap_err and expect_err methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,23 @@ A custom error message can be displayed instead by using `expect`::
         raise UnwrapError(message)
     result.result.UnwrapError: not ok
 
+Equivalent methods are available for accessing the error value::
+
+    >>> res1 = Ok('yay')
+    >>> res2 = Err('nay')
+    >>> res2.unwrap_err()
+    'nay'
+    >>> res2.expect_err('not an err')
+    'nay'
+    >>> res1.unwrap_err()
+    Traceback (most recent call last):
+    File "<stdin>", line 1, in <module>
+    File "C:\project\result\result\result.py", line 131, in unwrap_err
+        return self.expect_err("Called `Result.unwrap_err()` on an `Ok` value")
+    File "C:\project\result\result\result.py", line 123, in expect_err
+        raise UnwrapError(message)
+    result.result.UnwrapError: Called `Result.unwrap_err()` on an `Ok` value
+
 A default value can be returned instead by using `unwrap_or`::
 
     >>> res1 = Ok('yay')

--- a/result/result.py
+++ b/result/result.py
@@ -115,6 +115,21 @@ class Result(Generic[E, T]):
         else:
             return default
 
+    def expect_err(self, message: str) -> E:
+        """
+        Return the value if it is an `Err` type. Raises an `UnwrapError` if it is `Ok`.
+        """
+        if self._is_ok:
+            raise UnwrapError(message)
+        else:
+            return cast(E, self._value)
+
+    def unwrap_err(self) -> E:
+        """
+        Return the value if it is an `Err` type. Raises an `UnwrapError` if it is `Ok`.
+        """
+        return self.expect_err("Called `Result.unwrap_err()` on an `Ok` value")
+
     # TODO: Implement __iter__ for destructuring
 
 

--- a/result/tests.py
+++ b/result/tests.py
@@ -112,3 +112,19 @@ def test_unwrap_or():
     n = Err('nay')
     assert o.unwrap_or('some_default') == 'yay'
     assert n.unwrap_or('another_default') == 'another_default'
+
+
+def test_unwrap_err():
+    o = Ok('yay')
+    n = Err('nay')
+    assert n.unwrap_err() == 'nay'
+    with pytest.raises(UnwrapError):
+        o.unwrap_err()
+
+
+def test_expect_err():
+    o = Ok('yay')
+    n = Err('nay')
+    assert n.expect_err('hello') == 'nay'
+    with pytest.raises(UnwrapError):
+        o.expect_err('hello')


### PR DESCRIPTION
As their equivalents in Rust:

https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap_err
https://doc.rust-lang.org/std/result/enum.Result.html#method.expect_err