### PR TITLE
Typing constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - pip install -r requirements-dev.txt
   - pip install coveralls
 script:
+  - pip install -e .
   - py.test
   - mypy result/result.py
-  - python setup.py install
 after_success:
   - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 pytest==2.8.5
 pytest-cov==2.2.0
 pytest-pep8==1.0.6
-typing==3.6.1
 -e git+https://github.com/python/mypy@005fd6b357b995f13e3d90293cabf3c8c8c2a952#egg=mypy

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,4 @@ setup(name='result',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3 :: Only',
       ],
-      install_requires=['typing'])
+      install_requires=['typing; python_version < "3.5"'])


### PR DESCRIPTION
Only require typing module below Python 3.5.

Fixes #12.