### PR TITLE
Split Result type into Ok and Err class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,13 @@ Result
 A simple Result type for Python 3 `inspired by Rust <https://doc.rust-lang.org/std/result/>`__.
 
 The idea is that a ``Result`` value can be either ``Ok(value)`` or ``Err(error)``,
-with a way to differentiate between the two. It will change code like this:
+with a way to differentiate between the two. ``Ok`` and ``Err`` are both classes
+encapsulating an arbitrary value. ``Result[T, E]`` is a generic type alias for
+``typing.Union[Ok[T], Err[E]]``. It will change code like this:
 
 .. sourcecode:: python
 
-    def get_user_by_email(email):
+    def get_user_by_email(email: str) -> Tuple[Optional[User], Optional[str]]:
         """
         Return the user instance or an error message.
         """
@@ -37,9 +39,9 @@ To something like this:
 
 .. sourcecode:: python
 
-    from result import Ok, Err
+    from result import Ok, Err, Result
 
-    def get_user_by_email(email):
+    def get_user_by_email(email: str) -> Result[User, str]:
         """
         Return the user instance or an error message.
         """
@@ -51,19 +53,22 @@ To something like this:
         return Ok(user)
 
     user_result = get_user_by_email(email)
-    if user_result.is_ok():
+    if isinstance(user_result, Ok):
+        # type(user_result.value) == User
         do_something(user_result.value)
-    else: 
-        raise RuntimeError('Could not fetch user: %s' user_result.value)
+    else:
+        # type(value) == str
+        raise RuntimeError('Could not fetch user: %s' % user_result.value)
 
 As this is Python and not Rust, you will lose some of the advantages that it
 brings, like elegant combinations with the ``match`` statement. On the other
 side, you don't have to return semantically unclear tuples anymore.
 
 Not all methods (https://doc.rust-lang.org/std/result/enum.Result.html) have
-been implemented, only the ones that make sense in the Python context. You still
-don't get any type safety, but some easier handling of types that can be OK or
-not, without resorting to custom exceptions.
+been implemented, only the ones that make sense in the Python context. By using
+``isinstance`` to check for ``Ok`` or ``Err`` you get type safe access to the
+stored values. All of this in a package allowing easier handling of values
+that can be OK or not, without resorting to custom exceptions.
 
 
 API
@@ -75,15 +80,14 @@ Creating an instance::
     >>> res1 = Ok('yay')
     >>> res2 = Err('nay')
 
-Or through the class methods::
-
-    >>> from result import Result
-    >>> res1 = Result.Ok('yay')
-    >>> res2 = Result.Err('nay')
-
-Checking whether a result is ok or not::
+Checking whether a result is ok or not. With ``isinstance`` you get type safe
+access that can be checked with mypy::
 
     >>> res = Ok('yay')
+    >>> isinstance(res, Ok)
+    True
+    >>> isinstance(res, Err)
+    False
     >>> res.is_ok()
     True
     >>> res.is_err()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest==2.8.5
 pytest-cov==2.2.0
 pytest-pep8==1.0.6
--e git+https://github.com/python/mypy@005fd6b357b995f13e3d90293cabf3c8c8c2a952#egg=mypy
+mypy==0.730

--- a/result/tests.py
+++ b/result/tests.py
@@ -6,20 +6,14 @@ import pytest
 from result import Result, Ok, Err, UnwrapError
 
 
-@pytest.mark.parametrize('instance', [
-    Ok(1),
-    Result.Ok(1),
-])
-def test_ok_factories(instance):
+def test_ok_constructor():
+    instance = Ok(1)
     assert instance._value == 1
     assert instance.is_ok() is True
 
 
-@pytest.mark.parametrize('instance', [
-    Err(2),
-    Result.Err(2),
-])
-def test_err_factories(instance):
+def test_err_constructor():
+    instance = Err(2)
     assert instance._value == 2
     assert instance.is_err() is True
 
@@ -32,6 +26,7 @@ def test_eq():
     assert not (Ok(1) != Ok(1))
     assert Ok(1) != "abc"
     assert Ok("0") != Ok(0)
+    assert Err("0") != Err(0)
 
 
 def test_hash():
@@ -71,24 +66,6 @@ def test_err_method():
     n = Err('nay')
     assert o.err() is None
     assert n.err() == 'nay'
-
-
-def test_no_arg_ok():
-    top_level = Ok()
-    assert top_level.is_ok() is True
-    assert top_level.ok() is True
-
-    class_method = Result.Ok()
-    assert class_method.is_ok() is True
-    assert class_method.ok() is True
-
-
-def test_no_constructor():
-    """
-    Constructor should not be used directly.
-    """
-    with pytest.raises(RuntimeError):
-        Result(is_ok=True, value='yay')
 
 
 def test_unwrap():


### PR DESCRIPTION
and make `Result[T, E]` a type alias for `typing.Union[Ok[T], Err[E]]`.
This allows type safe access to the result members via isinstance
checks.

Implementation of #17 for discussion.

This is of course a big breaking change. I've switched the order of the `T` and `E` parameters to be in line with Rust. I haven't added the `Ok()` fallback for `Ok[bool]`, yet. I'm a bit confused on why that was added, especially with a `bool` member but it can of course be added again.

The big upside of this way is type safety. A downside is that you can no longer do checks like `isinstance(res, Result)` because `Result` is no longer a real type. Consequently, if you want to have a `Union[Result[T, E], U]`, it will be less ergonomic to go back to `Result[T, E]`.