### PR TITLE
Change left over `Result` to `OkErr` in the migrating guide

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -22,7 +22,7 @@ res2 = Err('nay')
 ```
 
 2\. Result is now a Union type between `Ok[T]` and `Err[E]`. As such, you cannot use `isinstance(res, Result)` anymore.
-These should be replaced by `isinstance(res, Result)`. As an example, the following code:
+These should be replaced by `isinstance(res, OkErr)`. As an example, the following code:
 
 ```python
 from result import Ok, Result


### PR DESCRIPTION
I missed something when writing the migration guide. `isinstance(res, Result)` should be replaced by `isinstance(res, OkErr)`, not by `isinstance(res, Result)` which is the exact same...