### PR TITLE
Implement and_then

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ codebase.
 
 [MIGRATING.md]: https://github.com/dbrgn/result/blob/master/MIGRATING.md
 
+- [added] Implement `and_then` (#32)
 - [changed] Split result type into `Ok` and `Err` classes (#17, #27)
 - [deprecated] Python 3.4 support is deprecated and will be removed in the next
   release

--- a/result/result.py
+++ b/result/result.py
@@ -122,7 +122,7 @@ class Ok(Generic[T]):
 
     def and_then(self, op: Callable[[T], 'Result[U, F]']) -> 'Result[U, F]':
         """
-        The contained result is `Ok`, so Calls `op` and returns a new `Result`
+        The contained result is `Ok`, so calls `op` and returns a new `Result`
         """
         return op(self._value)
 
@@ -233,7 +233,7 @@ class Err(Generic[E]):
 
     def and_then(self, op: Callable[[T], 'Result[U, E]']) -> 'Result[U, E]':
         """
-        Returns the `Err` value of self.
+        Returns the `Err` value of self
         """
         return self
 

--- a/result/result.py
+++ b/result/result.py
@@ -120,8 +120,9 @@ class Ok(Generic[T]):
         """
         return cast(Result[T, F], self)
 
-    def and_then(self, op: Callable[[T], 'Result[U, E]']) -> 'Result[U, E]':
+    def and_then(self, op: Callable[[T], 'Result[U, F]']) -> 'Result[U, F]':
         """
+        The contained result is `Ok`, so Calls `op` and returns a new `Result`
         """
         return op(self._value)
 
@@ -232,6 +233,7 @@ class Err(Generic[E]):
 
     def and_then(self, op: Callable[[T], 'Result[U, E]']) -> 'Result[U, E]':
         """
+        Returns the `Err` value of self.
         """
         return self
 

--- a/result/result.py
+++ b/result/result.py
@@ -120,6 +120,11 @@ class Ok(Generic[T]):
         """
         return cast(Result[T, F], self)
 
+    def and_then(self, op: Callable[[T], 'Result[U, E]']) -> 'Result[U, E]':
+        """
+        """
+        return op(self._value)
+
 
 class Err(Generic[E]):
     """
@@ -224,6 +229,11 @@ class Err(Generic[E]):
         a new value using the passed in function.
         """
         return Err(op(self._value))
+
+    def and_then(self, op: Callable[[T], 'Result[U, E]']) -> 'Result[U, E]':
+        """
+        """
+        return self
 
 
 # define Result as a generic type alias for use

--- a/result/tests.py
+++ b/result/tests.py
@@ -162,3 +162,24 @@ def test_isinstance_result_type():
     assert isinstance(o, OkErr)
     assert isinstance(n, OkErr)
     assert not isinstance(1, OkErr)
+
+
+def test_and_then_ok():
+    k = (Ok(1)
+        .and_then(lambda x: Ok(x + 1) if x > 0 else Err('too small'))
+        .and_then(lambda x: Ok(x ** 2)))
+    assert k.ok() == 4
+
+
+def test_and_then_err():
+    e = (Ok(1)
+        .and_then(lambda x: Ok(x + 1) if x > 5 else Err('too small'))
+        .and_then(lambda x: Ok(x ** 2)))
+    assert e.err() == 'too small'
+
+
+def test_and_then_start_with_err():
+    e = (Err('something went wrong')
+        .and_then(lambda x: Ok(x + 1) if x > 5 else Err('too small'))
+        .and_then(lambda x: Ok(x ** 2)))
+    assert e.err() == 'something went wrong'

--- a/result/typetests.py
+++ b/result/typetests.py
@@ -1,19 +1,36 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from .result import Result, Ok, Err
 
 
-res1 = Ok('hello')  # type: Result[str, int]
-if isinstance(res1, Ok):
-    ok = res1  # type: Ok[str]
-    okValue = res1.ok()  # type: str
-    mapped_to_float = res1.map_or(1.0, lambda s: len(s) * 1.5)  # type: float
-else:
-    err = res1  # type: Err[int]
-    errValue = err.err()  # type: int
-    mapped_to_list = res1.map_err(lambda e: [e]).err()  # type: Optional[List[int]]
-
 # Test constructor functions
-res1 = Ok()
-res2 = Ok(42)
-res3 = Err(1)
+res1 = Ok()  # type: Result[Any, Any]
+res2 = Ok(42)  # type: Result[int, Any]
+res3 = Err(1)  # type: Result[Any, int]
+
+res4 = Ok('hello')  # type: Result[str, int]
+if isinstance(res4, Ok):
+    ok = res4  # type: Ok[str]
+    okValue = res4.ok()  # type: str
+    mapped_to_float = res4.map_or(1.0, lambda s: len(s) * 1.5)  # type: float
+else:
+    err = res4  # type: Err[int]
+    errValue = err.err()  # type: int
+    mapped_to_list = res4.map_err(lambda e: [e]).err()  # type: Optional[List[int]]
+
+
+# Test mapping
+map_str_42 = Ok(42).map(str)  # type: Result[str, None]
+map_str_42_float = Ok(42).map(str).map(float)  # type: Result[float, Any]
+map_str_42_float_err = Ok(42).map_err(str).map(float)  # type: Result[float, str]
+
+
+# Test and_then
+and_then_str_42 = Ok(42).and_then(lambda x: Ok(str(x)))  # type: Result[str, None]
+
+
+def f(x: int) -> Result[str, Any]:
+    return Ok(str(x))
+
+
+and_then_str_42_float = Ok(42).and_then(f)  # type: Result[str, Any]


### PR DESCRIPTION
This is needed to allow `Result` returning functions to be chained,
```python
def get_user_input() -> Result[str, AppError]:
    return Ok('my name is alice')

def extract_name_from_input(inp: str) -> Result[str, AppError]:
    p = re.compile('my name is (\w+)')
    m = p.match(inp)
    if m is None: return Err(AppError.InvalidInput)
    return Ok(m.group(1))

def authorize_user(user: str) -> Result[bool, AppError]:
    if random() > 0.5: return Err(AppError.AuthorizationError)
    return Ok(user == 'alice')

auth_check = (
    get_user_input()
        .map(extract_name_from_input)
        .map(authorize_user)
) # type: Result[bool, AppError]
```
This doesn't work because `map` accepts functions that take some value and return a non-result value.
```
examples/with_result.py:24:1: error: Incompatible types in assignment (expression has type "Union[Ok[bool], Err[AppError], Err[<nothing>]]", variable has type "Union[Ok[bool], Err[AppError]]")
examples/with_result.py:25:5: error: Argument 1 to "map" of "Ok" has incompatible type "Callable[[str], Union[Ok[bool], Err[AppError]]]"; expected "Callable[[Union[Ok[str], Err[AppError]]], bool]"
examples/with_result.py:25:5: error: Argument 1 to "map" of "Err" has incompatible type "Callable[[str], Union[Ok[bool], Err[AppError]]]"; expected "Callable[[str], bool]"
```

```python
auth_check = (
    get_user_input()
        .and_then(extract_name_from_input)
        .and_then(authorize_user)
) # type: Result[bool, AppError]
```

This however does work.