### PR TITLE
Include `Result` in `UnwrapError`

### DIFF
--- a/result/result.py
+++ b/result/result.py
@@ -69,7 +69,7 @@ class Ok(Generic[T]):
         """
         Raise an UnwrapError since this type is `Ok`
         """
-        raise UnwrapError(message)
+        raise UnwrapError(self, message)
 
     def unwrap(self) -> T:
         """
@@ -81,7 +81,7 @@ class Ok(Generic[T]):
         """
         Raise an UnwrapError since this type is `Ok`
         """
-        raise UnwrapError("Called `Result.unwrap_err()` on an `Ok` value")
+        raise UnwrapError(self, "Called `Result.unwrap_err()` on an `Ok` value")
 
     def unwrap_or(self, _default: T) -> T:
         """
@@ -170,7 +170,7 @@ class Err(Generic[E]):
         """
         Raises an `UnwrapError`.
         """
-        raise UnwrapError(message)
+        raise UnwrapError(self, message)
 
     def expect_err(self, _message: str) -> E:
         """
@@ -182,7 +182,7 @@ class Err(Generic[E]):
         """
         Raises an `UnwrapError`.
         """
-        raise UnwrapError("Called `Result.unwrap()` on an `Err` value")
+        raise UnwrapError(self, "Called `Result.unwrap()` on an `Err` value")
 
     def unwrap_err(self) -> E:
         """
@@ -243,4 +243,10 @@ OkErr = (Ok, Err)
 
 
 class UnwrapError(Exception):
-    pass
+    def __init__(self, result: Result, message: str) -> None:
+        self._result = result
+        super().__init__(message)
+
+    @property
+    def result(self) -> Result:
+        return self._result

--- a/result/result.py
+++ b/result/result.py
@@ -243,10 +243,17 @@ OkErr = (Ok, Err)
 
 
 class UnwrapError(Exception):
+    """
+    Exception thrown upon `.unwrap_<...>` and `.expect_<...>` calls
+    """
+
     def __init__(self, result: Result, message: str) -> None:
         self._result = result
         super().__init__(message)
 
     @property
     def result(self) -> Result:
+        """
+        Returns the original result.
+        """
         return self._result

--- a/result/tests.py
+++ b/result/tests.py
@@ -162,3 +162,10 @@ def test_isinstance_result_type():
     assert isinstance(o, OkErr)
     assert isinstance(n, OkErr)
     assert not isinstance(1, OkErr)
+
+
+def test_error_context():
+    n = Err('nay')
+    with pytest.raises(UnwrapError) as e:
+        n.unwrap()
+    assert e.value.result is n


### PR DESCRIPTION
This PR should merely be regarded as a suggestion and to discuss if this change would be desirable.

Including the result when constructing `UnwrapError` enables using Python's exception semantics in a similar fashion to Rust's `?` early return operator. 

<details open>
<summary>Example usage</summary>

<p>Performing a series of failable operations, while obtaining context about the failed operation upon unwrapping. This is different from using regular exceptions in that the error type (which could also be an actual <code>Exception</code> or a <code>Union</code> type) is part of the function signature.</p>



```python
from result import Result, Ok, Err, UnwrapError
from dataclasses import dataclass

@dataclass
class ComputationError:
    number: int


def compute(number: int) -> Result[int, ComputationError]:
    return Ok(number) if number < 10 else Err(ComputationError(number))


a = compute(9)
b = compute(10)

try:
    c = a.unwrap() + b.unwrap()
except UnwrapError as e:
    print(f"Computation exception occurred: unexpected value '{e.result.value.number}'")
```

</details>

I've been using my fork of this library in various projects, and I've so far applied this pattern extensively.  
I'd appreciate if this change could be mainlined, as I don't really want to keep my fork around 😄.