### PR TITLE
Fix changelog release version references for 0.6.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@ codebase.
 
  - Initial version
 
-[Unreleased]: https://github.com/dbrgn/result/compare/v0.6.0-rc.1...HEAD
-[0.6.0-rc.1]: https://github.com/dbrgn/result/compare/v0.5.0...v0.6.0-rc.1
+[Unreleased]: https://github.com/dbrgn/result/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/dbrgn/result/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/dbrgn/result/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/dbrgn/result/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/dbrgn/result/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
Might've just forgotten to drop the 'rc` prefix during last release