### PR TITLE
Make Ok and Err covariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Possible log types:
 
 - `[removed]` Drop support for Python 3.5 (#34)
 - `[added]` Add support for Python 3.9
+- `[changed]` Make the `Ok` type covariant in regard to its wrapped type `T`.
+  Likewise for `Err` in regard to `E`. This should result in more intuitive 
+  type checking behaviour. For instance, `Err[TypeError]` will get recognized 
+  as a subtype of `Err[Exception]` by type checkers. See [PEP 438] for a 
+  detailed explanation of covariance and its implications.
+
+[PEP 438]: https://www.python.org/dev/peps/pep-0483/#covariance-and-contravariance
 
 ## [0.6.0] - 2021-03-17
 

--- a/result/result.py
+++ b/result/result.py
@@ -1,7 +1,7 @@
 from typing import Callable, Generic, TypeVar, Union, Any, cast, overload, NoReturn
 
-T = TypeVar("T")  # Success type
-E = TypeVar("E")  # Error type
+T = TypeVar("T", covariant=True)  # Success type
+E = TypeVar("E", covariant=True)  # Error type
 U = TypeVar("U")
 F = TypeVar("F")
 
@@ -83,7 +83,7 @@ class Ok(Generic[T]):
         """
         raise UnwrapError(self, "Called `Result.unwrap_err()` on an `Ok` value")
 
-    def unwrap_or(self, _default: T) -> T:
+    def unwrap_or(self, _default: U) -> T:
         """
         Return the value.
         """
@@ -190,7 +190,7 @@ class Err(Generic[E]):
         """
         return self._value
 
-    def unwrap_or(self, default: T) -> T:
+    def unwrap_or(self, default: U) -> U:
         """
         Return `default`.
         """

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -38,12 +38,12 @@
 
     ok_int: Ok[int] = Ok(42)
     ok_float: Ok[float] = ok_int
-    ok_int = ok_float  # E: Incompatible types in assignment (expression has type 'Ok[float]', variable has type 'Ok[int]')
+    ok_int = ok_float  # E: Incompatible types in assignment (expression has type "Ok[float]", variable has type "Ok[int]")
 
     err_type: Err[TypeError] = Err(TypeError("foo"))
     err_exc: Err[Exception] = err_type
-    err_type = err_exc  # E: Incompatible types in assignment (expression has type 'Err[Exception]', variable has type 'Err[TypeError]')
+    err_type = err_exc  # E: Incompatible types in assignment (expression has type "Err[Exception]", variable has type "Err[TypeError]")
 
     result_int_type: Result[int, TypeError] = ok_int or err_type
     result_float_exc: Result[float, Exception] = result_int_type
-    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type 'Union[Ok[float], Err[Exception]]', variable has type 'Union[Ok[int], Err[TypeError]]')
+    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type "Union[Ok[float], Err[Exception]]", variable has type "Union[Ok[int], Err[TypeError]]")

--- a/tests/type-checking/test_result.yml
+++ b/tests/type-checking/test_result.yml
@@ -31,3 +31,19 @@
     reveal_type(res2) # N: Revealed type is 'result.result.Ok[builtins.int*]'
     res3 = Err(1)
     reveal_type(res3) # N: Revealed type is 'result.result.Err[builtins.int*]'
+- case: covariance
+  disable_cache: false
+  main: |
+    from result import Result, Ok, Err
+
+    ok_int: Ok[int] = Ok(42)
+    ok_float: Ok[float] = ok_int
+    ok_int = ok_float  # E: Incompatible types in assignment (expression has type 'Ok[float]', variable has type 'Ok[int]')
+
+    err_type: Err[TypeError] = Err(TypeError("foo"))
+    err_exc: Err[Exception] = err_type
+    err_type = err_exc  # E: Incompatible types in assignment (expression has type 'Err[Exception]', variable has type 'Err[TypeError]')
+
+    result_int_type: Result[int, TypeError] = ok_int or err_type
+    result_float_exc: Result[float, Exception] = result_int_type
+    result_int_type = result_float_exc  # E: Incompatible types in assignment (expression has type 'Union[Ok[float], Err[Exception]]', variable has type 'Union[Ok[int], Err[TypeError]]')


### PR DESCRIPTION
Allow slightly more flexible typing, by letting `Ok` and `Err` be covariant.

A concrete example of when this is useful:
```py
# -*- coding: utf-8 -*-
# Code examples that should pass type checking with mypy
from typing import Union

from result import Ok, Err


def test_union_err() -> None:
    def union_err() -> Union[Err[str], Err[Exception]]:
        return Err("hello")

    # Should pass type check:
    # Union[Err[str], Err[Exception]] < Err[Union[str, Exception]]
    ue: Err[Union[str, Exception]] = union_err()


def test_union_ok() -> None:
    def union_ok() -> Union[Ok[str], Ok[int]]:
        return Ok("hello")

    # Should pass type check:
    # Union[Ok[str], Ok[int]] < Ok[Union[str, int]]
    uo: Ok[Union[str, int]] = union_ok()

```